### PR TITLE
Added a non-fatal console error when you try to add text inside a ima…

### DIFF
--- a/src/layout.ts
+++ b/src/layout.ts
@@ -332,6 +332,11 @@ export const calculateMeasurements = (
             `An image tag (<${tag.tagName}>) with ${IMG_STYLE_NAME}="${src}" was encountered, but there was no matching sprite in the sprite map. Please include a valid Sprite in the spriteMap property in the options in your RichText constructor.`
           );
         }
+        if (token.text !== "") {
+          console.error(
+            `Encountered tag <${tag.tagName}> which is recognized as an image tag ("${src}") but also contains the text "${token.text}". Text inside of image tags is not currently supported and has been removed.`
+          );
+        }
         token.text = " ";
         token.sprite = sprite;
 


### PR DESCRIPTION
Turns out adding the text is a little trickier than you might expect and would require some changes to how the tags are parsed. To patch this for the short term at least, I've added a check for non-empty image tags that logs an error to the console:

`Encountered tag <img> which is recognized as an image tag ("icon") but also contains the text "inside". Text inside of image tags is not currently supported.`

From here I see a few options:
1. This isn't good enough. Fix it for real asap
2. This patch is good enough _for now_. Accept this patch as is and fix it later.
3. This patch is good enough forever! No further changes needed.
4. This patch is fine but it would be better if it threw a real error so I could more easily message my users that there's a problem. 